### PR TITLE
feat(python): Introduce an Assortment of Python AST Nodes

### DIFF
--- a/generators/pythonv2/codegen/src/ast/CodeBlock.ts
+++ b/generators/pythonv2/codegen/src/ast/CodeBlock.ts
@@ -1,0 +1,22 @@
+import { CodeBlock as CommonCodeBlock } from "@fern-api/generator-commons";
+import { AstNode } from "./core/AstNode";
+import { Writer } from "./core/Writer";
+
+export declare namespace CodeBlock {
+    /* Write arbitrary code */
+    type Arg = CommonCodeBlock.Arg<Writer>;
+}
+
+export class CodeBlock extends AstNode {
+    private arg: CodeBlock.Arg;
+
+    public constructor(arg: CodeBlock.Arg) {
+        super();
+        this.arg = arg;
+    }
+
+    public write(writer: Writer): void {
+        const commonCodeBlock = new CommonCodeBlock(this.arg);
+        return commonCodeBlock.write(writer);
+    }
+}

--- a/generators/pythonv2/codegen/src/ast/Field.ts
+++ b/generators/pythonv2/codegen/src/ast/Field.ts
@@ -1,3 +1,4 @@
+import { CodeBlock } from "./CodeBlock";
 import { AstNode } from "./core/AstNode";
 import { Writer } from "./core/Writer";
 import { Type } from "./Type";
@@ -14,16 +15,16 @@ export declare namespace Field {
      */
     export type Args = BaseArgs &
         (
-            | { type: Type; initializer?: string }
-            | { type?: Type; initializer: string }
-            | { type: Type; initializer: string }
+            | { type: Type; initializer?: CodeBlock }
+            | { type?: Type; initializer: CodeBlock }
+            | { type: Type; initializer: CodeBlock }
         );
 }
 
 export class Field extends AstNode {
     public readonly name: string;
     public readonly type: Type | undefined;
-    public readonly initializer: string | undefined;
+    public readonly initializer: CodeBlock | undefined;
 
     constructor({ name, type, initializer }: Field.Args) {
         super();

--- a/generators/pythonv2/codegen/src/ast/Method.ts
+++ b/generators/pythonv2/codegen/src/ast/Method.ts
@@ -64,6 +64,10 @@ export class Method extends AstNode {
         this.decorators = decorators ?? [];
     }
 
+    public getName(): string {
+        return this.name;
+    }
+
     public write(writer: Writer): void {
         // Write decorators
         for (const decorator of this.decorators) {

--- a/generators/pythonv2/codegen/src/ast/Method.ts
+++ b/generators/pythonv2/codegen/src/ast/Method.ts
@@ -1,0 +1,121 @@
+import { AstNode } from "./core/AstNode";
+import { Writer } from "./core/Writer";
+import { Type } from "./Type";
+import { CodeBlock } from "./CodeBlock";
+import { ClassReference } from "./ClassReference";
+import { Field } from "./Field";
+
+export enum MethodType {
+    STATIC,
+    INSTANCE,
+    CLASS
+}
+
+export declare namespace Method {
+    interface Args {
+        /* The name of the method */
+        name: string;
+        /* The arguments of the method */
+        arguments_: Field[];
+        /* The return type of the method */
+        return_?: Type;
+        /* The body of the method */
+        body?: CodeBlock;
+        /* The docstring for the method */
+        docstring?: string;
+        /* The type of the method, defaults to STATIC */
+        type?: MethodType;
+        /* The class this method belongs to, if any */
+        classReference?: ClassReference;
+        /* Any decorators to add to the method */
+        decorators?: string[];
+    }
+}
+
+export class Method extends AstNode {
+    public readonly name: string;
+    public readonly return: Type | undefined;
+    public readonly body: CodeBlock | undefined;
+    public readonly docstring: string | undefined;
+    public readonly type: MethodType;
+    public readonly reference: ClassReference | undefined;
+    private readonly arguments_: Field[];
+    private readonly decorators: string[];
+
+    constructor({ name, arguments_, return_, body, docstring, type, classReference, decorators }: Method.Args) {
+        super();
+        this.name = name;
+        this.arguments_ = arguments_;
+        this.return = return_;
+        this.body = body;
+        this.docstring = docstring;
+        this.type = type ?? MethodType.STATIC;
+        this.reference = classReference;
+        this.decorators = decorators ?? [];
+    }
+
+    public write(writer: Writer): void {
+        // Write decorators
+        for (const decorator of this.decorators) {
+            writer.write(`@${decorator}`);
+            writer.newLine();
+        }
+        if (this.type === MethodType.CLASS) {
+            writer.write("@classmethod");
+            writer.newLine();
+        }
+
+        // Write method signature
+        writer.write(`def ${this.name}(`);
+        if (this.type === MethodType.INSTANCE) {
+            writer.write("self");
+            if (this.arguments_.length > 0) {
+                writer.write(", ");
+            }
+        }
+        if (this.type === MethodType.CLASS) {
+            writer.write("cls");
+            if (this.arguments_.length > 0) {
+                writer.write(", ");
+            }
+        }
+        this.arguments_.forEach((arg, index) => {
+            arg.write(writer);
+            if (index < this.arguments_.length - 1) {
+                writer.write(", ");
+            }
+        });
+        writer.write(")");
+
+        // Write return type if specified
+        if (this.return) {
+            writer.write(" -> ");
+            this.return.write(writer);
+        }
+
+        writer.write(":");
+        writer.newLine();
+
+        // Write docstring if specified
+        if (this.docstring) {
+            writer.indent();
+            writer.write('"""');
+            writer.write(this.docstring);
+            writer.write('"""');
+            writer.newLine();
+            writer.dedent();
+        }
+
+        // Write method body
+        if (this.body) {
+            writer.indent();
+            this.body.write(writer);
+            writer.dedent();
+        } else {
+            writer.indent();
+            writer.write("pass");
+            writer.newLine();
+            writer.dedent();
+        }
+    }
+}

--- a/generators/pythonv2/codegen/src/ast/Method.ts
+++ b/generators/pythonv2/codegen/src/ast/Method.ts
@@ -4,6 +4,7 @@ import { Type } from "./Type";
 import { CodeBlock } from "./CodeBlock";
 import { ClassReference } from "./ClassReference";
 import { Field } from "./Field";
+import { Parameter } from "./Parameter";
 
 export enum MethodType {
     STATIC,
@@ -15,8 +16,8 @@ export declare namespace Method {
     interface Args {
         /* The name of the method */
         name: string;
-        /* The arguments of the method */
-        arguments_: Field[];
+        /* The parameters of the method */
+        parameters: Parameter[];
         /* The return type of the method */
         return_?: Type;
         /* The body of the method */
@@ -39,17 +40,26 @@ export class Method extends AstNode {
     public readonly docstring: string | undefined;
     public readonly type: MethodType;
     public readonly reference: ClassReference | undefined;
-    private readonly arguments_: Field[];
+    private readonly parameters: Parameter[];
     private readonly decorators: string[];
 
-    constructor({ name, arguments_, return_, body, docstring, type, classReference, decorators }: Method.Args) {
+    constructor({
+        name,
+        parameters,
+        return_,
+        body,
+        docstring,
+        type = MethodType.STATIC,
+        classReference,
+        decorators
+    }: Method.Args) {
         super();
         this.name = name;
-        this.arguments_ = arguments_;
+        this.parameters = parameters;
         this.return = return_;
         this.body = body;
         this.docstring = docstring;
-        this.type = type ?? MethodType.STATIC;
+        this.type = type;
         this.reference = classReference;
         this.decorators = decorators ?? [];
     }
@@ -69,19 +79,19 @@ export class Method extends AstNode {
         writer.write(`def ${this.name}(`);
         if (this.type === MethodType.INSTANCE) {
             writer.write("self");
-            if (this.arguments_.length > 0) {
+            if (this.parameters.length > 0) {
                 writer.write(", ");
             }
         }
         if (this.type === MethodType.CLASS) {
             writer.write("cls");
-            if (this.arguments_.length > 0) {
+            if (this.parameters.length > 0) {
                 writer.write(", ");
             }
         }
-        this.arguments_.forEach((arg, index) => {
-            arg.write(writer);
-            if (index < this.arguments_.length - 1) {
+        this.parameters.forEach((param, index) => {
+            param.write(writer);
+            if (index < this.parameters.length - 1) {
                 writer.write(", ");
             }
         });

--- a/generators/pythonv2/codegen/src/ast/MethodArgument.ts
+++ b/generators/pythonv2/codegen/src/ast/MethodArgument.ts
@@ -1,0 +1,32 @@
+import { CodeBlock } from "./CodeBlock";
+import { AstNode } from "./core/AstNode";
+import { Writer } from "./core/Writer";
+import { Type } from "./Type";
+
+export declare namespace MethodArgument {
+    interface Args {
+        /* If a kwarg, then the name of the parameter that this is a keyword argument for */
+        name?: string;
+        /* The value of the argument */
+        value: CodeBlock;
+    }
+}
+
+export class MethodArgument extends AstNode {
+    public readonly name: string | undefined;
+    public readonly value: CodeBlock;
+
+    constructor({ name, value }: MethodArgument.Args) {
+        super();
+        this.name = name;
+        this.value = value;
+    }
+
+    public write(writer: Writer): void {
+        if (this.name !== undefined) {
+            writer.write(this.name);
+            writer.write("=");
+        }
+        this.value.write(writer);
+    }
+}

--- a/generators/pythonv2/codegen/src/ast/MethodInvocation.ts
+++ b/generators/pythonv2/codegen/src/ast/MethodInvocation.ts
@@ -1,0 +1,41 @@
+import { python } from "..";
+import { CodeBlock } from "./CodeBlock";
+import { AstNode } from "./core/AstNode";
+import { Writer } from "./core/Writer";
+import { Method } from "./Method";
+import { MethodArgument } from "./MethodArgument";
+
+export declare namespace MethodInvocation {
+    interface Args {
+        /* The method to invoke */
+        method: Method | string;
+        /* The arguments to pass to the method */
+        arguments_: MethodArgument[];
+    }
+}
+
+export class MethodInvocation extends AstNode {
+    private methodName: string;
+    private arguments: MethodArgument[];
+
+    constructor({ method, arguments_ }: MethodInvocation.Args) {
+        super();
+
+        this.methodName = typeof method === "string" ? method : method.getName();
+        this.arguments = arguments_;
+    }
+
+    public write(writer: Writer): void {
+        writer.write(this.methodName);
+        writer.write("(");
+
+        this.arguments.forEach((arg, idx) => {
+            arg.write(writer);
+            if (idx < this.arguments.length - 1) {
+                writer.write(", ");
+            }
+        });
+
+        writer.write(")");
+    }
+}

--- a/generators/pythonv2/codegen/src/ast/Parameter.ts
+++ b/generators/pythonv2/codegen/src/ast/Parameter.ts
@@ -1,0 +1,39 @@
+import { CodeBlock } from "./CodeBlock";
+import { AstNode } from "./core/AstNode";
+import { Writer } from "./core/Writer";
+import { Type } from "./Type";
+
+export declare namespace Parameter {
+    interface Args {
+        /* The name of the parameter */
+        name: string;
+        /* The type of the parameter */
+        type: Type;
+        /* The initializer for the parameter */
+        initializer?: CodeBlock;
+    }
+}
+
+export class Parameter extends AstNode {
+    public readonly name: string;
+    public readonly initializer: CodeBlock | undefined;
+    public readonly type: Type;
+
+    constructor({ name, type, initializer }: Parameter.Args) {
+        super();
+        this.name = name;
+        this.type = type;
+        this.initializer = initializer;
+    }
+
+    public write(writer: Writer): void {
+        writer.write(this.name);
+        writer.write(": ");
+        this.type.write(writer);
+
+        if (this.initializer !== undefined) {
+            writer.write(" = ");
+            this.initializer.write(writer);
+        }
+    }
+}

--- a/generators/pythonv2/codegen/src/ast/__test__/Class.test.ts
+++ b/generators/pythonv2/codegen/src/ast/__test__/Class.test.ts
@@ -12,12 +12,14 @@ describe("class", () => {
         const clazz = python.class_({
             name: "Car"
         });
-        clazz.addField(python.field({ name: "color", type: python.Type.str(), initializer: "'red'" }));
+        clazz.addField(
+            python.field({ name: "color", type: python.Type.str(), initializer: python.codeBlock("'red'") })
+        );
         clazz.addField(
             python.field({
                 name: "partNameById",
                 type: python.Type.dict(python.Type.int(), python.Type.str()),
-                initializer: "{}"
+                initializer: python.codeBlock("{}")
             })
         );
         expect(clazz.toString()).toMatchSnapshot();

--- a/generators/pythonv2/codegen/src/ast/__test__/CodeBlock.test.ts
+++ b/generators/pythonv2/codegen/src/ast/__test__/CodeBlock.test.ts
@@ -1,0 +1,42 @@
+import { python } from "../..";
+import { Writer } from "../core/Writer";
+
+describe("CodeBlock", () => {
+    let writer: Writer;
+
+    beforeEach(() => {
+        writer = new Writer();
+    });
+
+    describe("toString", () => {
+        it("returns an empty string for an empty code block", () => {
+            const codeBlock = python.codeBlock("");
+            expect(codeBlock.toString()).toMatchSnapshot();
+        });
+
+        it("returns a single line of code", () => {
+            const codeBlock = python.codeBlock('print("Hello, World!")');
+            expect(codeBlock.toString()).toMatchSnapshot();
+        });
+
+        it("returns multiple lines of code", () => {
+            const codeBlock = python.codeBlock(`\
+def greet(name):
+    return f"Hello, {name}!"
+
+print(greet("Alice"))\
+`);
+            expect(codeBlock.toString()).toMatchSnapshot();
+        });
+
+        it("preserves indentation", () => {
+            const codeBlock = python.codeBlock(`\
+if True:
+    print("Indented")
+    if False:
+        print("Nested indentation")\
+`);
+            expect(codeBlock.toString()).toMatchSnapshot();
+        });
+    });
+});

--- a/generators/pythonv2/codegen/src/ast/__test__/Field.test.ts
+++ b/generators/pythonv2/codegen/src/ast/__test__/Field.test.ts
@@ -21,7 +21,7 @@ describe("Field", () => {
         const field = python.field({
             name: "my_int",
             type: python.Type.int(),
-            initializer: "42"
+            initializer: python.codeBlock("42")
         });
         field.write(writer);
         expect(writer.toString()).toMatchSnapshot();
@@ -30,7 +30,7 @@ describe("Field", () => {
     it("writes a field with a name and value but no type", () => {
         const field = python.field({
             name: "my_field",
-            initializer: "'default_value'"
+            initializer: python.codeBlock("'default_value'")
         });
         field.write(writer);
         expect(writer.toString()).toMatchSnapshot();
@@ -40,7 +40,7 @@ describe("Field", () => {
         const field = python.field({
             name: "my_list",
             type: python.Type.list(python.Type.int()),
-            initializer: "[]"
+            initializer: python.codeBlock("[]")
         });
         field.write(writer);
         expect(writer.toString()).toMatchSnapshot();

--- a/generators/pythonv2/codegen/src/ast/__test__/Method.test.ts
+++ b/generators/pythonv2/codegen/src/ast/__test__/Method.test.ts
@@ -8,7 +8,7 @@ describe("Method", () => {
         it("should generate a static method", () => {
             const method = python.method({
                 name: "static_method",
-                arguments_: [],
+                parameters: [],
                 type: MethodType.STATIC
             });
             expect(method.toString()).toMatchSnapshot();
@@ -17,7 +17,7 @@ describe("Method", () => {
         it("should generate an instance method", () => {
             const method = python.method({
                 name: "instance_method",
-                arguments_: [],
+                parameters: [],
                 type: MethodType.INSTANCE
             });
             expect(method.toString()).toMatchSnapshot();
@@ -26,7 +26,7 @@ describe("Method", () => {
         it("should generate a class method", () => {
             const method = python.method({
                 name: "class_method",
-                arguments_: [],
+                parameters: [],
                 type: MethodType.CLASS
             });
             expect(method.toString()).toMatchSnapshot();
@@ -35,7 +35,7 @@ describe("Method", () => {
         it("should generate a method with one argument", () => {
             const method = python.method({
                 name: "one_arg",
-                arguments_: [python.field({ name: "arg1", type: python.Type.str() })]
+                parameters: [python.parameter({ name: "arg1", type: python.Type.str() })]
             });
             expect(method.toString()).toMatchSnapshot();
         });
@@ -43,9 +43,9 @@ describe("Method", () => {
         it("should generate a method with multiple arguments", () => {
             const method = python.method({
                 name: "multi_args",
-                arguments_: [
-                    python.field({ name: "arg1", type: python.Type.str() }),
-                    python.field({ name: "arg2", type: python.Type.int() })
+                parameters: [
+                    python.parameter({ name: "arg1", type: python.Type.str() }),
+                    python.parameter({ name: "arg2", type: python.Type.int() })
                 ]
             });
             expect(method.toString()).toMatchSnapshot();
@@ -54,7 +54,7 @@ describe("Method", () => {
         it("should generate a method with a specified return type", () => {
             const method = python.method({
                 name: "with_return",
-                arguments_: [],
+                parameters: [],
                 return_: python.Type.bool()
             });
             expect(method.toString()).toMatchSnapshot();
@@ -63,7 +63,7 @@ describe("Method", () => {
         it("should generate a method without a specified return type", () => {
             const method = python.method({
                 name: "without_return",
-                arguments_: []
+                parameters: []
             });
             expect(method.toString()).toMatchSnapshot();
         });
@@ -71,7 +71,7 @@ describe("Method", () => {
         it("should generate a method with a body", () => {
             const method = python.method({
                 name: "with_body",
-                arguments_: [],
+                parameters: [],
                 body: python.codeBlock("return True")
             });
             expect(method.toString()).toMatchSnapshot();
@@ -80,7 +80,7 @@ describe("Method", () => {
         it("should generate a method without a body", () => {
             const method = python.method({
                 name: "without_body",
-                arguments_: []
+                parameters: []
             });
             expect(method.toString()).toMatchSnapshot();
         });
@@ -88,7 +88,7 @@ describe("Method", () => {
         it("should generate a method with a docstring", () => {
             const method = python.method({
                 name: "with_docstring",
-                arguments_: [],
+                parameters: [],
                 docstring: "This is a docstring"
             });
             expect(method.toString()).toMatchSnapshot();
@@ -97,7 +97,7 @@ describe("Method", () => {
         it("should generate a method without a docstring", () => {
             const method = python.method({
                 name: "without_docstring",
-                arguments_: []
+                parameters: []
             });
             expect(method.toString()).toMatchSnapshot();
         });
@@ -105,7 +105,7 @@ describe("Method", () => {
         it("should generate a method with a single decorator", () => {
             const method = python.method({
                 name: "single_decorator",
-                arguments_: [],
+                parameters: [],
                 decorators: ["decorator1"]
             });
             expect(method.toString()).toMatchSnapshot();
@@ -114,7 +114,7 @@ describe("Method", () => {
         it("should generate a method with multiple decorators", () => {
             const method = python.method({
                 name: "multiple_decorators",
-                arguments_: [],
+                parameters: [],
                 decorators: ["decorator1", "decorator2"]
             });
             expect(method.toString()).toMatchSnapshot();

--- a/generators/pythonv2/codegen/src/ast/__test__/Method.test.ts
+++ b/generators/pythonv2/codegen/src/ast/__test__/Method.test.ts
@@ -1,0 +1,123 @@
+import { MethodType } from "../Method";
+import { Type } from "../Type";
+import { CodeBlock } from "../CodeBlock";
+import { python } from "../..";
+
+describe("Method", () => {
+    describe("toString", () => {
+        it("should generate a static method", () => {
+            const method = python.method({
+                name: "static_method",
+                arguments_: [],
+                type: MethodType.STATIC
+            });
+            expect(method.toString()).toMatchSnapshot();
+        });
+
+        it("should generate an instance method", () => {
+            const method = python.method({
+                name: "instance_method",
+                arguments_: [],
+                type: MethodType.INSTANCE
+            });
+            expect(method.toString()).toMatchSnapshot();
+        });
+
+        it("should generate a class method", () => {
+            const method = python.method({
+                name: "class_method",
+                arguments_: [],
+                type: MethodType.CLASS
+            });
+            expect(method.toString()).toMatchSnapshot();
+        });
+
+        it("should generate a method with one argument", () => {
+            const method = python.method({
+                name: "one_arg",
+                arguments_: [python.field({ name: "arg1", type: python.Type.str() })]
+            });
+            expect(method.toString()).toMatchSnapshot();
+        });
+
+        it("should generate a method with multiple arguments", () => {
+            const method = python.method({
+                name: "multi_args",
+                arguments_: [
+                    python.field({ name: "arg1", type: python.Type.str() }),
+                    python.field({ name: "arg2", type: python.Type.int() })
+                ]
+            });
+            expect(method.toString()).toMatchSnapshot();
+        });
+
+        it("should generate a method with a specified return type", () => {
+            const method = python.method({
+                name: "with_return",
+                arguments_: [],
+                return_: python.Type.bool()
+            });
+            expect(method.toString()).toMatchSnapshot();
+        });
+
+        it("should generate a method without a specified return type", () => {
+            const method = python.method({
+                name: "without_return",
+                arguments_: []
+            });
+            expect(method.toString()).toMatchSnapshot();
+        });
+
+        it("should generate a method with a body", () => {
+            const method = python.method({
+                name: "with_body",
+                arguments_: [],
+                body: python.codeBlock("return True")
+            });
+            expect(method.toString()).toMatchSnapshot();
+        });
+
+        it("should generate a method without a body", () => {
+            const method = python.method({
+                name: "without_body",
+                arguments_: []
+            });
+            expect(method.toString()).toMatchSnapshot();
+        });
+
+        it("should generate a method with a docstring", () => {
+            const method = python.method({
+                name: "with_docstring",
+                arguments_: [],
+                docstring: "This is a docstring"
+            });
+            expect(method.toString()).toMatchSnapshot();
+        });
+
+        it("should generate a method without a docstring", () => {
+            const method = python.method({
+                name: "without_docstring",
+                arguments_: []
+            });
+            expect(method.toString()).toMatchSnapshot();
+        });
+
+        it("should generate a method with a single decorator", () => {
+            const method = python.method({
+                name: "single_decorator",
+                arguments_: [],
+                decorators: ["decorator1"]
+            });
+            expect(method.toString()).toMatchSnapshot();
+        });
+
+        it("should generate a method with multiple decorators", () => {
+            const method = python.method({
+                name: "multiple_decorators",
+                arguments_: [],
+                decorators: ["decorator1", "decorator2"]
+            });
+            expect(method.toString()).toMatchSnapshot();
+        });
+    });
+});

--- a/generators/pythonv2/codegen/src/ast/__test__/MethodInvocation.test.ts
+++ b/generators/pythonv2/codegen/src/ast/__test__/MethodInvocation.test.ts
@@ -1,0 +1,61 @@
+import { MethodInvocation } from "../MethodInvocation";
+import { Writer } from "../core/Writer";
+import { python } from "../..";
+
+describe("MethodInvocation", () => {
+    it("should write a method invocation with no args", () => {
+        const invocation = new MethodInvocation({
+            method: "test_method",
+            arguments_: []
+        });
+
+        const writer = new Writer();
+        invocation.write(writer);
+
+        expect(writer.toString()).toBe("test_method()");
+    });
+
+    it("should write a method invocation with one positional arg", () => {
+        const invocation = new MethodInvocation({
+            method: "test_method",
+            arguments_: [python.methodArgument({ value: python.codeBlock("42") })]
+        });
+
+        const writer = new Writer();
+        invocation.write(writer);
+
+        expect(writer.toString()).toBe("test_method(42)");
+    });
+
+    it("should write a method invocation with one positional arg and one kwarg", () => {
+        const invocation = new MethodInvocation({
+            method: "test_method",
+            arguments_: [
+                python.methodArgument({ value: python.codeBlock("42") }),
+                python.methodArgument({ name: "key", value: python.codeBlock("'value'") })
+            ]
+        });
+
+        const writer = new Writer();
+        invocation.write(writer);
+
+        expect(writer.toString()).toBe("test_method(42, key='value')");
+    });
+
+    it("should write a method invocation with multiple positional and kwarg args", () => {
+        const invocation = new MethodInvocation({
+            method: "test_method",
+            arguments_: [
+                python.methodArgument({ value: python.codeBlock("42") }),
+                python.methodArgument({ value: python.codeBlock("'hello'") }),
+                python.methodArgument({ name: "key1", value: python.codeBlock("True") }),
+                python.methodArgument({ name: "key2", value: python.codeBlock("[1, 2, 3]") })
+            ]
+        });
+
+        const writer = new Writer();
+        invocation.write(writer);
+
+        expect(writer.toString()).toBe("test_method(42, 'hello', key1=True, key2=[1, 2, 3])");
+    });
+});

--- a/generators/pythonv2/codegen/src/ast/__test__/__snapshots__/CodeBlock.test.ts.snap
+++ b/generators/pythonv2/codegen/src/ast/__test__/__snapshots__/CodeBlock.test.ts.snap
@@ -1,0 +1,19 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CodeBlock > toString > preserves indentation 1`] = `
+"if True:
+    print("Indented")
+    if False:
+        print("Nested indentation")"
+`;
+
+exports[`CodeBlock > toString > returns a single line of code 1`] = `"print("Hello, World!")"`;
+
+exports[`CodeBlock > toString > returns an empty string for an empty code block 1`] = `""`;
+
+exports[`CodeBlock > toString > returns multiple lines of code 1`] = `
+"def greet(name):
+    return f"Hello, {name}!"
+
+print(greet("Alice"))"
+`;

--- a/generators/pythonv2/codegen/src/ast/__test__/__snapshots__/Method.test.ts.snap
+++ b/generators/pythonv2/codegen/src/ast/__test__/__snapshots__/Method.test.ts.snap
@@ -1,0 +1,83 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Method > toString > should generate a class method 1`] = `
+"@classmethod
+def class_method(cls):
+    pass
+"
+`;
+
+exports[`Method > toString > should generate a method with a body 1`] = `
+"def with_body():
+    return True"
+`;
+
+exports[`Method > toString > should generate a method with a docstring 1`] = `
+"def with_docstring():
+    """This is a docstring"""
+    pass
+"
+`;
+
+exports[`Method > toString > should generate a method with a single decorator 1`] = `
+"@decorator1
+def single_decorator():
+    pass
+"
+`;
+
+exports[`Method > toString > should generate a method with a specified return type 1`] = `
+"def with_return() -> bool:
+    pass
+"
+`;
+
+exports[`Method > toString > should generate a method with multiple arguments 1`] = `
+"def multi_args(arg1: str, arg2: int):
+    pass
+"
+`;
+
+exports[`Method > toString > should generate a method with multiple decorators 1`] = `
+"@decorator1
+@decorator2
+def multiple_decorators():
+    pass
+"
+`;
+
+exports[`Method > toString > should generate a method with one argument 1`] = `
+"def one_arg(arg1: str):
+    pass
+"
+`;
+
+exports[`Method > toString > should generate a method without a body 1`] = `
+"def without_body():
+    pass
+"
+`;
+
+exports[`Method > toString > should generate a method without a docstring 1`] = `
+"def without_docstring():
+    pass
+"
+`;
+
+exports[`Method > toString > should generate a method without a specified return type 1`] = `
+"def without_return():
+    pass
+"
+`;
+
+exports[`Method > toString > should generate a static method 1`] = `
+"def static_method():
+    pass
+"
+`;
+
+exports[`Method > toString > should generate an instance method 1`] = `
+"def instance_method(self):
+    pass
+"
+`;

--- a/generators/pythonv2/codegen/src/ast/index.ts
+++ b/generators/pythonv2/codegen/src/ast/index.ts
@@ -3,3 +3,5 @@ export { Field } from "./Field";
 export { Writer } from "./core/Writer";
 export { Type } from "./Type";
 export { ClassReference } from "./ClassReference";
+export { CodeBlock } from "./CodeBlock";
+export { AstNode } from "./core/AstNode";

--- a/generators/pythonv2/codegen/src/ast/index.ts
+++ b/generators/pythonv2/codegen/src/ast/index.ts
@@ -7,3 +7,4 @@ export { CodeBlock } from "./CodeBlock";
 export { AstNode } from "./core/AstNode";
 export { Method } from "./Method";
 export { Parameter } from "./Parameter";
+export { MethodArgument } from "./MethodArgument";

--- a/generators/pythonv2/codegen/src/ast/index.ts
+++ b/generators/pythonv2/codegen/src/ast/index.ts
@@ -6,3 +6,4 @@ export { ClassReference } from "./ClassReference";
 export { CodeBlock } from "./CodeBlock";
 export { AstNode } from "./core/AstNode";
 export { Method } from "./Method";
+export { Parameter } from "./Parameter";

--- a/generators/pythonv2/codegen/src/ast/index.ts
+++ b/generators/pythonv2/codegen/src/ast/index.ts
@@ -5,3 +5,4 @@ export { Type } from "./Type";
 export { ClassReference } from "./ClassReference";
 export { CodeBlock } from "./CodeBlock";
 export { AstNode } from "./core/AstNode";
+export { Method } from "./Method";

--- a/generators/pythonv2/codegen/src/python.ts
+++ b/generators/pythonv2/codegen/src/python.ts
@@ -1,4 +1,4 @@
-import { Class, Field, ClassReference, CodeBlock, Method } from "./ast";
+import { Class, Field, ClassReference, CodeBlock, Method, Parameter } from "./ast";
 
 export function class_(args: Class.Args): Class {
     return new Class(args);
@@ -18,6 +18,10 @@ export function codeBlock(args: CodeBlock.Arg): CodeBlock {
 
 export function method(args: Method.Args): Method {
     return new Method(args);
+}
+
+export function parameter(args: Parameter.Args): Parameter {
+    return new Parameter(args);
 }
 
 export { AstNode, Class, Field, Type, Writer, ClassReference, CodeBlock, Method } from "./ast";

--- a/generators/pythonv2/codegen/src/python.ts
+++ b/generators/pythonv2/codegen/src/python.ts
@@ -1,4 +1,4 @@
-import { Class, Field, Type, Writer, ClassReference } from "./ast";
+import { Class, Field, ClassReference, CodeBlock } from "./ast";
 
 export function class_(args: Class.Args): Class {
     return new Class(args);
@@ -12,4 +12,8 @@ export function field(args: Field.Args): Field {
     return new Field(args);
 }
 
-export { Class, Field, Type, Writer } from "./ast";
+export function codeBlock(args: CodeBlock.Arg): CodeBlock {
+    return new CodeBlock(args);
+}
+
+export { AstNode, Class, Field, Type, Writer, ClassReference, CodeBlock } from "./ast";

--- a/generators/pythonv2/codegen/src/python.ts
+++ b/generators/pythonv2/codegen/src/python.ts
@@ -1,4 +1,4 @@
-import { Class, Field, ClassReference, CodeBlock } from "./ast";
+import { Class, Field, ClassReference, CodeBlock, Method } from "./ast";
 
 export function class_(args: Class.Args): Class {
     return new Class(args);
@@ -16,4 +16,8 @@ export function codeBlock(args: CodeBlock.Arg): CodeBlock {
     return new CodeBlock(args);
 }
 
-export { AstNode, Class, Field, Type, Writer, ClassReference, CodeBlock } from "./ast";
+export function method(args: Method.Args): Method {
+    return new Method(args);
+}
+
+export { AstNode, Class, Field, Type, Writer, ClassReference, CodeBlock, Method } from "./ast";

--- a/generators/pythonv2/codegen/src/python.ts
+++ b/generators/pythonv2/codegen/src/python.ts
@@ -1,4 +1,4 @@
-import { Class, Field, ClassReference, CodeBlock, Method, Parameter } from "./ast";
+import { Class, Field, ClassReference, CodeBlock, Method, Parameter, MethodArgument } from "./ast";
 
 export function class_(args: Class.Args): Class {
     return new Class(args);
@@ -22,6 +22,10 @@ export function method(args: Method.Args): Method {
 
 export function parameter(args: Parameter.Args): Parameter {
     return new Parameter(args);
+}
+
+export function methodArgument(args: MethodArgument.Args): MethodArgument {
+    return new MethodArgument(args);
 }
 
 export { AstNode, Class, Field, Type, Writer, ClassReference, CodeBlock, Method } from "./ast";


### PR DESCRIPTION
This PR introduces the following new ATS nodes for python. Most are directly influenced from csharp.

* `CodeBlock` – I also refactored existing initializers to use these instead of strings
* `Method` – Feels more Pythonic to call these "Functions," but I stuck to "Method" for consistency
* `Parameter` – Used to define arguments on a Method. At first my instinct was to reuse `Field` for this, but opted for consistency
* `MethodInvocation` – Used to invoke a method
* `MethodArgument` – Passed to MethodInvocation and a departure from csharp. Needed by python to support positional vs keyword arguments.